### PR TITLE
feat: support custom loop key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
-# svelte-virtual-list changelog
+# svelte-virtual-list-enhanced changelog
 
+## 3.1.1
+
+* Added custom loop index to improve re-renders
+
+# 3.1.0
+ 
+ * Fork from tje3d/svelte-virtual-list 
+ 
 ## 3.0.1
 
 * Prevent missing `itemHeight` prop warning

--- a/README.md
+++ b/README.md
@@ -9,18 +9,18 @@ A virtual list component for Svelte apps. Instead of rendering all your data, `<
 ## Installation
 
 ```bash
-yarn add @lionixevolve/svelte-virtual-list-enchanced
+yarn add @lionixevolve/svelte-virtual-list-enhanced
 ```
 Or npm
 ```bash
-npm i --save @lionixevolve/svelte-virtual-list-enchanced
+npm i --save @lionixevolve/svelte-virtual-list-enhanced
 ```
 
 ## Usage
 
 ```html
 <script>
-  import VirtualList from '@lionixevolve/svelte-virtual-list-enchanced';
+  import VirtualList from '@lionixevolve/svelte-virtual-list-enhanced';
 
   const things = [
     // these can be any values you like

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# ATTENTION THIS IS A WORK IN PROGRESS FORK FROM RICHARD'S OWN VIRTUAL-LIST LIBRARY (he is not maintaining it properly) 
+# ATTENTION THIS IS A WORK IN PROGRESS FORK 
+FROM RICHARD'S OWN VIRTUAL-LIST LIBRARY (he is not maintaining it currently) 
 It has some undocumented new functionalities that can be seen from the commit list
 
 # svelte-virtual-list-enhanced ([demo](https://svelte.dev/repl/f78ddd84a1a540a9a40512df39ef751b))
@@ -8,15 +9,18 @@ A virtual list component for Svelte apps. Instead of rendering all your data, `<
 ## Installation
 
 ```bash
-yarn add svelte-virtual-list-enchanced
+yarn add @lionixevolve/svelte-virtual-list-enchanced
 ```
-
+Or npm
+```bash
+npm i --save @lionixevolve/svelte-virtual-list-enchanced
+```
 
 ## Usage
 
 ```html
 <script>
-  import VirtualList from 'svelte-virtual-list-enchanced';
+  import VirtualList from '@lionixevolve/svelte-virtual-list-enchanced';
 
   const things = [
     // these can be any values you like

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
-# svelte-virtual-list ([demo](https://svelte.dev/repl/f78ddd84a1a540a9a40512df39ef751b))
+# ATTENTION THIS IS A WORK IN PROGRESS FORK FROM RICHARD'S OWN VIRTUAL-LIST LIBRARY (he is not maintaining it properly) 
+It has some undocumented new functionalities that can be seen from the commit list
+
+# svelte-virtual-list-enhanced ([demo](https://svelte.dev/repl/f78ddd84a1a540a9a40512df39ef751b))
 
 A virtual list component for Svelte apps. Instead of rendering all your data, `<VirtualList>` just renders the bits that are visible, keeping your page nice and light.
 
 ## Installation
 
 ```bash
-yarn add @sveltejs/svelte-virtual-list
+yarn add svelte-virtual-list-enchanced
 ```
 
 
@@ -13,7 +16,7 @@ yarn add @sveltejs/svelte-virtual-list
 
 ```html
 <script>
-  import VirtualList from '@sveltejs/svelte-virtual-list';
+  import VirtualList from 'svelte-virtual-list-enchanced';
 
   const things = [
     // these can be any values you like

--- a/VirtualList.svelte
+++ b/VirtualList.svelte
@@ -1,185 +1,190 @@
 <script>
-	import { onMount, tick, createEventDispatcher } from 'svelte'
+  import { onMount, tick, createEventDispatcher } from "svelte";
 
-	// props
-	export let items
-	export let height = '100%'
-	export let itemHeight = undefined
+  // props
+  export let items;
+  export let height = "100%";
+  export let itemHeight = undefined;
 
-	// read-only, but visible to consumers via bind:start
-	export let start = 0
-	export let end = 0
-	export const getViewport = () => viewport
-	export const toTop = () => (viewport.scrollTop = 0)
-	export const toBottom = () => (viewport.scrollTop = viewport.scrollHeight)
+  // read-only, but visible to consumers via bind:start
+  export let start = 0;
+  export let end = 0;
+  export const getViewport = () => viewport;
+  export const toTop = () => (viewport.scrollTop = 0);
+  export const toBottom = () => (viewport.scrollTop = viewport.scrollHeight);
+  export let customLoopKeyName = "";
 
-	// local state
-	let height_map = []
-	let rows
-	let viewport
-	let contents
-	let viewport_height = 0
-	let visible
-	let mounted
-	const dispatch = createEventDispatcher()
+  // local state
+  let height_map = [];
+  let rows;
+  let viewport;
+  let contents;
+  let viewport_height = 0;
+  let visible;
+  let mounted;
+  const dispatch = createEventDispatcher();
 
-	let top = 0
-	let bottom = 0
-	let average_height
+  let top = 0;
+  let bottom = 0;
+  let average_height;
 
-	$: visible = items.slice(start, end).map((data, i) => {
-		return { index: i + start, data }
-	})
+  $: visible = items.slice(start, end).map((data, i) => {
+    let index = i + start;
+    if (customLoopKeyName !== "" && data[customLoopKeyName]) {
+      index = data[customLoopKeyName];
+    }
+    return { index: index, data };
+  });
 
-	// whenever `items` changes, invalidate the current heightmap
-	$: if (mounted) refresh(items, viewport_height, itemHeight)
+  // whenever `items` changes, invalidate the current heightmap
+  $: if (mounted) refresh(items, viewport_height, itemHeight);
 
-	export async function doRefresh() {
-		return refresh(items, viewport_height, itemHeight)
-	}
+  export async function doRefresh() {
+    return refresh(items, viewport_height, itemHeight);
+  }
 
-	async function refresh(items, viewport_height, itemHeight) {
-		const { scrollTop } = viewport
+  async function refresh(items, viewport_height, itemHeight) {
+    const { scrollTop } = viewport;
 
-		await tick() // wait until the DOM is up to date
+    await tick(); // wait until the DOM is up to date
 
-		let content_height = top - scrollTop
-		let i = start
+    let content_height = top - scrollTop;
+    let i = start;
 
-		while (content_height < viewport_height && i < items.length) {
-			let row = rows[i - start]
+    while (content_height < viewport_height && i < items.length) {
+      let row = rows[i - start];
 
-			if (!row) {
-				end = i + 1
-				await tick() // render the newly visible row
-				row = rows[i - start]
-			}
+      if (!row) {
+        end = i + 1;
+        await tick(); // render the newly visible row
+        row = rows[i - start];
+      }
 
-			const row_height = (height_map[i] = itemHeight || row.offsetHeight)
-			content_height += row_height
-			i += 1
-		}
+      const row_height = (height_map[i] = itemHeight || row.offsetHeight);
+      content_height += row_height;
+      i += 1;
+    }
 
-		end = i
+    end = i;
 
-		const remaining = items.length - end
-		average_height = (top + content_height) / end
+    const remaining = items.length - end;
+    average_height = (top + content_height) / end;
 
-		bottom = remaining * average_height
-		height_map.length = items.length
-	}
+    bottom = remaining * average_height;
+    height_map.length = items.length;
+  }
 
-	async function handle_scroll(event) {
-		const { scrollTop, clientHeight, scrollHeight } = viewport
+  async function handle_scroll(event) {
+    const { scrollTop, clientHeight, scrollHeight } = viewport;
 
-		if (scrollTop === 0) {
-			dispatch('onTopReached')
-		} else if (scrollTop + clientHeight >= scrollHeight) {
-			dispatch('onEndReached')
-		}
+    if (scrollTop === 0) {
+      dispatch("onTopReached");
+    } else if (scrollTop + clientHeight >= scrollHeight) {
+      dispatch("onEndReached");
+    }
 
-		const old_start = start
+    const old_start = start;
 
-		for (let v = 0; v < rows.length; v += 1) {
-			height_map[start + v] = itemHeight || rows[v].offsetHeight
-		}
+    for (let v = 0; v < rows.length; v += 1) {
+      height_map[start + v] = itemHeight || rows[v].offsetHeight;
+    }
 
-		let i = 0
-		let y = 0
+    let i = 0;
+    let y = 0;
 
-		while (i < items.length) {
-			const row_height = height_map[i] || average_height
-			if (y + row_height > scrollTop) {
-				start = i
-				top = y
+    while (i < items.length) {
+      const row_height = height_map[i] || average_height;
+      if (y + row_height > scrollTop) {
+        start = i;
+        top = y;
 
-				break
-			}
+        break;
+      }
 
-			y += row_height
-			i += 1
-		}
+      y += row_height;
+      i += 1;
+    }
 
-		while (i < items.length) {
-			y += height_map[i] || average_height
-			i += 1
+    while (i < items.length) {
+      y += height_map[i] || average_height;
+      i += 1;
 
-			if (y > scrollTop + viewport_height) break
-		}
+      if (y > scrollTop + viewport_height) break;
+    }
 
-		end = i
+    end = i;
 
-		const remaining = items.length - end
-		average_height = y / end
+    const remaining = items.length - end;
+    average_height = y / end;
 
-		while (i < items.length) height_map[i++] = average_height
-		bottom = remaining * average_height
+    while (i < items.length) height_map[i++] = average_height;
+    bottom = remaining * average_height;
 
-		// prevent jumping if we scrolled up into unknown territory
-		if (start < old_start) {
-			await tick()
+    // prevent jumping if we scrolled up into unknown territory
+    if (start < old_start) {
+      await tick();
 
-			let expected_height = 0
-			let actual_height = 0
+      let expected_height = 0;
+      let actual_height = 0;
 
-			for (let i = start; i < old_start; i += 1) {
-				if (rows[i - start]) {
-					expected_height += height_map[i]
-					actual_height += itemHeight || rows[i - start].offsetHeight
-				}
-			}
+      for (let i = start; i < old_start; i += 1) {
+        if (rows[i - start]) {
+          expected_height += height_map[i];
+          actual_height += itemHeight || rows[i - start].offsetHeight;
+        }
+      }
 
-			const d = actual_height - expected_height
-			viewport.scrollTo(0, scrollTop + d)
-		}
+      const d = actual_height - expected_height;
+      viewport.scrollTo(0, scrollTop + d);
+    }
 
-		dispatch('scroll', event)
+    dispatch("scroll", event);
 
-		// TODO if we overestimated the space these
-		// rows would occupy we may need to add some
-		// more. maybe we can just call handle_scroll again?
-	}
+    // TODO if we overestimated the space these
+    // rows would occupy we may need to add some
+    // more. maybe we can just call handle_scroll again?
+  }
 
-	// trigger initial refresh
-	onMount(() => {
-		rows = contents.getElementsByTagName('svelte-virtual-list-row')
-		mounted = true
-	})
+  // trigger initial refresh
+  onMount(() => {
+    rows = contents.getElementsByTagName("svelte-virtual-list-row");
+    mounted = true;
+  });
 </script>
 
 <style>
-	svelte-virtual-list-viewport {
-		position: relative;
-		overflow-y: auto;
-		-webkit-overflow-scrolling: touch;
-		display: block;
-	}
+  svelte-virtual-list-viewport {
+    position: relative;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    display: block;
+  }
 
-	svelte-virtual-list-contents,
-	svelte-virtual-list-row {
-		display: block;
-	}
+  svelte-virtual-list-contents,
+  svelte-virtual-list-row {
+    display: block;
+  }
 
-	svelte-virtual-list-row {
-		overflow: hidden;
-	}
+  svelte-virtual-list-row {
+    overflow: hidden;
+  }
 </style>
 
 <svelte-virtual-list-viewport
-	bind:this={viewport}
-	bind:offsetHeight={viewport_height}
-	on:scroll={handle_scroll}
-	style="height: {height};"
-	on:touchstart
-	on:touchmove
-	on:mousewheel>
-	<svelte-virtual-list-contents
-		bind:this={contents}
-		style="padding-top: {top}px; padding-bottom: {bottom}px;">
-		{#each visible as row (row.index)}
-			<svelte-virtual-list-row>
-				<slot item={row.data}>Missing template</slot>
-			</svelte-virtual-list-row>
-		{/each}
-	</svelte-virtual-list-contents>
+  bind:this={viewport}
+  bind:offsetHeight={viewport_height}
+  on:scroll={handle_scroll}
+  style="height: {height};"
+  on:touchstart
+  on:touchmove
+  on:mousewheel>
+  <svelte-virtual-list-contents
+    bind:this={contents}
+    style="padding-top: {top}px; padding-bottom: {bottom}px;">
+    {#each visible as row (row.index)}
+      <svelte-virtual-list-row>
+        <slot item={row.data}>Missing template</slot>
+      </svelte-virtual-list-row>
+    {/each}
+  </svelte-virtual-list-contents>
 </svelte-virtual-list-viewport>

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "tape-modern": "^1.1.1"
   },
   "repository": "https://github.com/sveltejs/svelte-virtual-list",
-  "author": "Rich Harris",
+  "author": "Rich Harris + evolved by some folks from lionix and the world",
   "license": "LIL",
   "keywords": [
     "svelte"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@lionix/svelte-virtual-list-enhanced",
+    "name": "@lionixevolve/svelte-virtual-list-enhanced",
     "version": "1.2.0",
     "description": "A <VirtualList> component for Svelte apps",
     "main": "VirtualList.svelte",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lionixevolve/svelte-virtual-list-enhanced",
-    "version": "1.2.1",
+    "version": "3.1.1",
     "description": "A <VirtualList> component for Svelte apps",
     "main": "VirtualList.svelte",
     "svelte": "VirtualList.svelte",

--- a/package.json
+++ b/package.json
@@ -1,42 +1,53 @@
 {
-  "name": "svelte-virtual-list-enhanced",
-  "version": "1.2.0",
-  "description": "A <VirtualList> component for Svelte apps",
-  "main": "VirtualList.svelte",
-  "svelte": "VirtualList.svelte",
-  "scripts": {
-    "build": "rollup -c",
-    "dev": "rollup -cw",
-    "prepublishOnly": "npm test",
-    "test": "node test/runner.js",
-    "test:browser": "npm run build && serve test/public",
-    "pretest": "npm run build",
-    "lint": "eslint src/VirtualList.svelte"
-  },
-  "devDependencies": {
-    "eslint": "^5.12.1",
-    "eslint-plugin-svelte3": "git+https://github.com/sveltejs/eslint-plugin-svelte3.git",
-    "port-authority": "^1.0.5",
-    "puppeteer": "^1.9.0",
-    "rollup": "^1.1.2",
-    "rollup-plugin-commonjs": "^9.2.0",
-    "rollup-plugin-node-resolve": "^4.0.0",
-    "rollup-plugin-svelte": "^5.0.1",
-    "sirv": "^0.2.2",
-    "svelte": "^3.0.0-beta.2",
-    "tap-diff": "^0.1.1",
-    "tap-dot": "^2.0.0",
-    "tape-modern": "^1.1.1"
-  },
-  "repository": "https://github.com/sveltejs/svelte-virtual-list",
-  "author": "Rich Harris",
-  "license": "LIL",
-  "keywords": [
-    "svelte"
-  ],
-  "files": [
-    "src",
-    "index.mjs",
-    "index.js"
-  ]
+    "name": "@lionix/svelte-virtual-list-enhanced",
+    "version": "1.2.0",
+    "description": "A <VirtualList> component for Svelte apps",
+    "main": "VirtualList.svelte",
+    "svelte": "VirtualList.svelte",
+    "scripts": {
+        "build": "rollup -c",
+        "dev": "rollup -cw",
+        "prepublishOnly": "npm test",
+        "test": "node test/runner.js",
+        "test:browser": "npm run build && serve test/public",
+        "pretest": "npm run build",
+        "lint": "eslint src/VirtualList.svelte"
+    },
+    "devDependencies": {
+        "eslint": "^5.12.1",
+        "eslint-plugin-svelte3": "git+https://github.com/sveltejs/eslint-plugin-svelte3.git",
+        "port-authority": "^1.0.5",
+        "puppeteer": "^1.9.0",
+        "rollup": "^1.1.2",
+        "rollup-plugin-commonjs": "^9.2.0",
+        "rollup-plugin-node-resolve": "^4.0.0",
+        "rollup-plugin-svelte": "^5.0.1",
+        "sirv": "^0.2.2",
+        "svelte": "^3.0.0-beta.2",
+        "tap-diff": "^0.1.1",
+        "tap-dot": "^2.0.0",
+        "tape-modern": "^1.1.1"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/lionixevolve/svelte-virtual-list-enhanced.git"
+    },
+    "author": "Rich Harris + tje3d + Lionix folks",
+    "license": "SEE LICENSE IN LICENSE",
+    "keywords": [
+        "svelte"
+    ],
+    "files": [
+        "src",
+        "index.mjs",
+        "index.js"
+    ],
+    "bugs": {
+        "url": "https://github.com/lionixevolve/svelte-virtual-list-enhanced/issues"
+    },
+    "homepage": "https://github.com/lionixevolve/svelte-virtual-list-enhanced#readme",
+    "directories": {
+        "test": "test"
+    },
+    "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lionixevolve/svelte-virtual-list-enhanced",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "description": "A <VirtualList> component for Svelte apps",
     "main": "VirtualList.svelte",
     "svelte": "VirtualList.svelte",


### PR DESCRIPTION
When a source data item is modified Svelte will not re-render the child Node due to the use of an Index as a key instead of a unique proper key (like an ID from a DB that is included in the DATA as a property)
This change add the support to support such a key, if it is not set, the default index is used, but if its set, the property sent is used as a key. 